### PR TITLE
Dont panic squash

### DIFF
--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -148,7 +148,17 @@ impl<'s> LhsFieldExpr<'s> {
                 CompiledExpr::new(move |ctx| func(call.execute(ctx)))
             }
             LhsFieldExpr::Field(f) => {
-                CompiledExpr::new(move |ctx| func(ctx.get_field_value_unchecked(f)))
+                CompiledExpr::new(move |ctx| {
+                    let field_opt = ctx.get_field_value_unchecked(f);
+                    match field_opt {
+                        Some(f) => {
+                            func(f)
+                        },
+                        None => { //If we do not find the field, we consider this a non match
+                            false
+                        }
+                    }
+                })
             }
         }
     }

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -145,19 +145,14 @@ impl<'s> LhsFieldExpr<'s> {
     {
         match self {
             LhsFieldExpr::FunctionCallExpr(call) => {
-                CompiledExpr::new(move |ctx| func(call.execute(ctx)))
+                CompiledExpr::new(move |ctx| {
+                    Some(func(call.execute(ctx)))
+                })
             }
             LhsFieldExpr::Field(f) => {
                 CompiledExpr::new(move |ctx| {
-                    let field_opt = ctx.get_field_value_unchecked(f);
-                    match field_opt {
-                        Some(f) => {
-                            func(f)
-                        },
-                        None => { //If we do not find the field, we consider this a non match
-                            false
-                        }
-                    }
+                    let field_opt = ctx.get_field_value(f);
+                    field_opt.map(|f| func(f))
                 })
             }
         }
@@ -445,10 +440,10 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("ssl", true).unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("ssl", false).unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
     }
 
     #[test]
@@ -480,25 +475,25 @@ mod tests {
 
         ctx.set_field_value("ip.addr", IpAddr::from([0, 0, 0, 0, 0, 0, 0, 1]))
             .unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value(
             "ip.addr",
             IpAddr::from([0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]),
         )
         .unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value(
             "ip.addr",
             IpAddr::from([0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x81]),
         )
         .unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("ip.addr", IpAddr::from([127, 0, 0, 1]))
             .unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
     }
 
     #[test]
@@ -575,10 +570,10 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("http.host", "example.com").unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("http.host", "example.org").unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
     }
 
     #[test]
@@ -607,10 +602,10 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("tcp.port", 80).unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("tcp.port", 443).unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
     }
 
     #[test]
@@ -640,25 +635,25 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("tcp.port", 80).unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("tcp.port", 8080).unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("tcp.port", 443).unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("tcp.port", 2081).unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("tcp.port", 2082).unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("tcp.port", 2083).unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("tcp.port", 2084).unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
     }
 
     #[test]
@@ -692,13 +687,13 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("http.host", "example.com").unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("http.host", "example.org").unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("http.host", "example.net").unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
     }
 
     #[test]
@@ -738,23 +733,23 @@ mod tests {
 
         ctx.set_field_value("ip.addr", IpAddr::from([127, 0, 0, 1]))
             .unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("ip.addr", IpAddr::from([127, 0, 0, 3]))
             .unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("ip.addr", IpAddr::from([255, 255, 255, 255]))
             .unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("ip.addr", IpAddr::from([0, 0, 0, 0, 0, 0, 0, 1]))
             .unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("ip.addr", IpAddr::from([0, 0, 0, 0, 0, 0, 0, 2]))
             .unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
     }
 
     #[test]
@@ -780,10 +775,10 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("http.host", "example.org").unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("http.host", "abc.net.au").unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
     }
 
     #[test]
@@ -809,10 +804,10 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("http.host", "example.com").unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("http.host", "example.org").unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
     }
 
     #[test]
@@ -841,10 +836,10 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("tcp.port", 80).unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("tcp.port", 8080).unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
     }
 
     #[test]
@@ -887,10 +882,10 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("http.host", "example.com").unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("http.host", "example.org").unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
     }
 
     #[test]
@@ -933,10 +928,10 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("http.host", "EXAMPLE.COM").unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         ctx.set_field_value("http.host", "EXAMPLE.ORG").unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
     }
 
     #[test]
@@ -979,10 +974,10 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("http.host", "example.org").unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("http.host", "example.co.uk").unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
 
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"concat(http.host, ".org") == "example.org""#, &SCHEME),
@@ -1029,9 +1024,9 @@ mod tests {
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
         ctx.set_field_value("http.host", "example").unwrap();
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
 
         ctx.set_field_value("http.host", "cloudflare").unwrap();
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
     }
 }

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -27,7 +27,7 @@ impl<'s> FunctionCallArgExpr<'s> {
         match self {
             FunctionCallArgExpr::LhsFieldExpr(lhs) => match lhs {
                 LhsFieldExpr::Field(field) => {
-                    ctx.get_field_value_unchecked(*field)
+                    ctx.get_field_value(*field)
                 },
                 LhsFieldExpr::FunctionCallExpr(call) => Some(call.execute(ctx)),
             },

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -23,13 +23,15 @@ impl<'s> FunctionCallArgExpr<'s> {
         }
     }
 
-    pub fn execute(&'s self, ctx: &'s ExecutionContext<'s>) -> LhsValue<'s> {
+    pub fn execute(&'s self, ctx: &'s ExecutionContext<'s>) -> Option<LhsValue<'s>> {
         match self {
             FunctionCallArgExpr::LhsFieldExpr(lhs) => match lhs {
-                LhsFieldExpr::Field(field) => ctx.get_field_value_unchecked(*field),
-                LhsFieldExpr::FunctionCallExpr(call) => call.execute(ctx),
+                LhsFieldExpr::Field(field) => {
+                    ctx.get_field_value_unchecked(*field)
+                },
+                LhsFieldExpr::FunctionCallExpr(call) => Some(call.execute(ctx)),
             },
-            FunctionCallArgExpr::Literal(literal) => literal.into(),
+            FunctionCallArgExpr::Literal(literal) => Some(literal.into()),
         }
     }
 }
@@ -93,7 +95,7 @@ impl<'s> FunctionCallExpr<'s> {
 
     pub fn execute(&self, ctx: &'s ExecutionContext<'s>) -> LhsValue<'_> {
         self.function.implementation.execute(
-            self.args.iter().map(|arg| arg.execute(ctx)).chain(
+            self.args.iter().flat_map(|arg| arg.execute(ctx)).chain(
                 self.function.opt_params[self.args.len() - self.function.params.len()..]
                     .iter()
                     .map(|opt_arg| opt_arg.default_value.as_ref()),

--- a/engine/src/ast/simple_expr.rs
+++ b/engine/src/ast/simple_expr.rs
@@ -63,7 +63,7 @@ impl<'s> Expr<'s> for SimpleExpr<'s> {
                 arg,
             } => {
                 let arg = arg.compile();
-                CompiledExpr::new(move |ctx| !arg.execute(ctx))
+                CompiledExpr::new(move |ctx| arg.execute(ctx).map(|x| !x))
             }
         }
     }
@@ -94,7 +94,7 @@ fn test() {
 
         let expr = expr.compile();
 
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
     }
 
     let parenthesized_expr = |expr| SimpleExpr::Parenthesized(Box::new(CombinedExpr::Simple(expr)));
@@ -115,7 +115,7 @@ fn test() {
 
         let expr = expr.compile();
 
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
     }
 
     let not_expr = |expr| SimpleExpr::Unary {
@@ -139,7 +139,7 @@ fn test() {
 
         let expr = expr.compile();
 
-        assert_eq!(expr.execute(ctx), false);
+        assert_eq!(expr.execute(ctx), Some(false));
     }
 
     assert_ok!(SimpleExpr::lex_with("!t", scheme), not_expr(t_expr()));
@@ -166,7 +166,7 @@ fn test() {
 
         let expr = expr.compile();
 
-        assert_eq!(expr.execute(ctx), true);
+        assert_eq!(expr.execute(ctx), Some(true));
     }
 
     assert_ok!(

--- a/engine/src/execution_context.rs
+++ b/engine/src/execution_context.rs
@@ -29,7 +29,7 @@ impl<'e> ExecutionContext<'e> {
         self.scheme
     }
 
-    pub(crate) fn get_field_value_unchecked(&'e self, field: Field<'e>) -> Option<LhsValue<'e>> {
+    pub(crate) fn get_field_value(&'e self, field: Field<'e>) -> Option<LhsValue<'e>> {
         // This is safe because this code is reachable only from Filter::execute
         // which already performs the scheme compatibility check, but check that
         // invariant holds in the future at least in the debug mode.

--- a/engine/src/execution_context.rs
+++ b/engine/src/execution_context.rs
@@ -29,22 +29,14 @@ impl<'e> ExecutionContext<'e> {
         self.scheme
     }
 
-    pub(crate) fn get_field_value_unchecked(&'e self, field: Field<'e>) -> LhsValue<'e> {
+    pub(crate) fn get_field_value_unchecked(&'e self, field: Field<'e>) -> Option<LhsValue<'e>> {
         // This is safe because this code is reachable only from Filter::execute
         // which already performs the scheme compatibility check, but check that
         // invariant holds in the future at least in the debug mode.
         debug_assert!(self.scheme() == field.scheme());
 
-        // For now we panic in this, but later we are going to align behaviour
-        // with wireshark: resolve all subexpressions that don't have RHS value
-        // to `false`.
-        let lhs_value = self.values[field.index()].as_ref().unwrap_or_else(|| {
-            panic!(
-                "Field {} was registered but not given a value",
-                field.name()
-            );
-        });
-        lhs_value.as_ref()
+        let lhs_value = self.values[field.index()].as_ref();
+        lhs_value.map(|e| e.as_ref())
     }
 
     /// Sets a runtime value for a given field name.
@@ -87,3 +79,4 @@ fn test_field_value_type_mismatch() {
         })
     );
 }
+

--- a/engine/src/filter.rs
+++ b/engine/src/filter.rs
@@ -80,6 +80,15 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_against_present_value_1() {
+        let scheme = Scheme! { foo: Int, bar: Int };
+        let filter = scheme.parse("bar == 41").unwrap().compile();
+        let mut ctx = ExecutionContext::new(&scheme);
+        ctx.set_field_value("bar", LhsValue::Int(41)).unwrap();
+        assert_eq!(filter.execute(&ctx), Ok(Some(true)));
+    }
+
+    #[test]
     fn test_filter_against_missing_value_1() {
         let scheme = Scheme! { foo: Int, bar: Int };
         let filter = scheme.parse("bar == 41").unwrap().compile();
@@ -102,6 +111,15 @@ mod tests {
         let mut ctx = ExecutionContext::new(&scheme);
         ctx.set_field_value("foo", LhsValue::Int(52)).unwrap();
         ctx.set_field_value("bar", LhsValue::Int(41)).unwrap();
+        assert_eq!(filter.execute(&ctx), Ok(Some(true)));
+    }
+
+    #[test]
+    fn test_filter_against_or_value() {
+        let scheme = Scheme! { foo: Int, bar: Int };
+        let filter = scheme.parse("bar == 41 || foo == 52").unwrap().compile();
+        let mut ctx = ExecutionContext::new(&scheme);
+        ctx.set_field_value("foo", LhsValue::Int(52)).unwrap();
         assert_eq!(filter.execute(&ctx), Ok(Some(true)));
     }
 

--- a/engine/src/filter.rs
+++ b/engine/src/filter.rs
@@ -67,6 +67,7 @@ impl<'s> Filter<'s> {
 mod tests {
     use super::{Filter, SchemeMismatchError};
     use crate::execution_context::ExecutionContext;
+    use crate::LhsValue;
 
     #[test]
     fn test_scheme_mismatch() {
@@ -76,6 +77,32 @@ mod tests {
         let ctx = ExecutionContext::new(&scheme2);
 
         assert_eq!(filter.execute(&ctx), Err(SchemeMismatchError));
+    }
+
+    #[test]
+    fn test_filter_against_missing_value_1() {
+        let scheme = Scheme! { foo: Int, bar: Int };
+        let filter = scheme.parse("bar == 41").unwrap().compile();
+        let mut ctx = ExecutionContext::new(&scheme);
+        ctx.set_field_value("foo", LhsValue::Int(41)).unwrap();
+        assert_eq!(filter.execute(&ctx), Ok(false));
+    }
+    #[test]
+    fn test_filter_against_missing_value_2() {
+        let scheme = Scheme! { foo: Int, bar: Int };
+        let filter = scheme.parse("foo == 41").unwrap().compile();
+        let mut ctx = ExecutionContext::new(&scheme);
+        ctx.set_field_value("bar", LhsValue::Int(41)).unwrap();
+        assert_eq!(filter.execute(&ctx), Ok(false));
+    }
+    #[test]
+    fn test_filter_against_ooo_value() {
+        let scheme = Scheme! { foo: Int, bar: Int };
+        let filter = scheme.parse("bar == 41 && foo == 52").unwrap().compile();
+        let mut ctx = ExecutionContext::new(&scheme);
+        ctx.set_field_value("foo", LhsValue::Int(52)).unwrap();
+        ctx.set_field_value("bar", LhsValue::Int(41)).unwrap();
+        assert_eq!(filter.execute(&ctx), Ok(true));
     }
 
     #[test]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -212,7 +212,7 @@ pub extern "C" fn wirefilter_match<'s>(
     filter: &Filter<'s>,
     exec_context: &ExecutionContext<'s>,
 ) -> bool {
-    filter.execute(exec_context).unwrap()
+    filter.execute(exec_context).unwrap().unwrap_or(false)
 }
 
 #[no_mangle]


### PR DESCRIPTION
Change to the interface to return option... a None result means that not enough members were included in the execution context to execute the filter.